### PR TITLE
Split large pages multiple times in preview mode with one call to applyAutomaticPageBreaks()

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,8 @@
 			for (var d = docs.length - 1; d >= 0; d--) {
 				pages = docs[d].querySelectorAll(".page");
 
-				for (var p = pages.length - 1; p >= 0; p--) {
+				var p = 0
+				while (p < pages.length) {
 					if (pages[p].clientHeight > pageHeightInPixels) {
 						pages[p].insertAdjacentHTML("afterend", "<div class=\"page\" contenteditable=\"true\"></div>");
 						pageCoords = pages[p].getBoundingClientRect();
@@ -109,7 +110,9 @@
 								pages[p].nextElementSibling.insertBefore(snippets[s], pages[p].nextElementSibling.firstChild);
 							}
 						}
+						pages = docs[d].querySelectorAll('.page')
 					}
+					p++
 				}
 			}
 		}


### PR DESCRIPTION
This PR changes the `applyAutomaticPageBreaks()` function to enable splitting really large pages multiple times instead of splitting it just once per `applyAutomaticPageBreaks()` function call.
Without this change a page with for example 50 Lorem Ipsum paragraphs gets rendered in the browser as one correctly sized page and another page much larger than the chosen page size. This other page gets further split into more correctly sized pages each time the user clicks outside the _.document_ block to trigger the function.
With this change the necessary splits happen with only one call to `applyAutomaticPageBreaks()` and therefore the page gets correctly displayed on initial render.

For my use case this change was used to correctly insert page numbers (in both preview and print mode) at the bottom of each _.page_ on initial render. This was necessary because my page‘s content gets loaded from a database and I couldn’t be sure how long the content would be.

Thank you for this great software 👍